### PR TITLE
♻️ make function kpt compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ metadata:
         path: krmfnbuiltin
     # Can also be:
     #  container:
-    #    image: ghcr.io/kaweezle/krmfnbuiltin:v0.2.0
+    #    image: ghcr.io/kaweezle/krmfnbuiltin:v0.3.0
 patch: |-
   - op: replace
       path: /spec/source/repoURL
@@ -824,7 +824,7 @@ curl -sLS https://raw.githubusercontent.com/kaweezle/krmfnbuiltin/main/get.sh | 
 If you don't want to pipe into shell, you can do:
 
 ```console
-> KRMFNBUILTIN_VERSION="v0.2.0"
+> KRMFNBUILTIN_VERSION="v0.3.0"
 > curl -sLo /usr/local/bin/krmfnbuiltin https://github.com/kaweezle/krmfnbuiltin/releases/download/${KRMFNBUILTIN_VERSION}/krmfnbuiltin_${KRMFNBUILTIN_VERSION}_linux_amd64
 ```
 
@@ -853,7 +853,7 @@ summarize:
 ```Dockerfile
 FROM argoproj/argocd:latest
 
-ARG KRMFNBUILTIN_VERSION=v0.2.0
+ARG KRMFNBUILTIN_VERSION=v0.3.0
 
 # Switch to root for the ability to perform install
 USER root

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
-	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -84,11 +83,6 @@ func main() {
 				err = rl.Filter(utils.UnLocal)
 				if err != nil {
 					return errors.WrapPrefixf(err, "Removing local from keep-local resources")
-				}
-				filter := &filters.IsLocalConfig{IncludeLocalConfig: false, ExcludeNonLocalConfig: false}
-				err = rl.Filter(filter)
-				if err != nil {
-					return errors.WrapPrefixf(err, "filtering local configs")
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	cmd := command.Build(processor, command.StandaloneDisabled, false)
 	command.AddGenerateDockerfile(cmd)
-	cmd.Version = "v0.2.0" // <---VERSION--->
+	cmd.Version = "v0.3.0" // <---VERSION--->
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/extras/RemoveTransformer.go
+++ b/pkg/extras/RemoveTransformer.go
@@ -1,0 +1,46 @@
+package extras
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/yaml"
+)
+
+type RemoveTransformerPlugin struct {
+	Targets []*types.Selector `json:"targets,omitempty" yaml:"targets,omitempty"`
+}
+
+func (p *RemoveTransformerPlugin) Config(
+	h *resmap.PluginHelpers, c []byte) (err error) {
+	err = yaml.Unmarshal(c, p)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (p *RemoveTransformerPlugin) Transform(m resmap.ResMap) error {
+	if p.Targets == nil {
+		return fmt.Errorf("must specify at least one target")
+	}
+	for _, t := range p.Targets {
+		resources, err := m.Select(*t)
+		if err != nil {
+			return errors.WrapPrefixf(err, "while selecting target %s", t.String())
+		}
+		for _, r := range resources {
+			err = m.Remove(r.CurId())
+			if err != nil {
+				return errors.WrapPrefixf(err, "while removing resource %s", r.CurId().String())
+			}
+		}
+	}
+	return nil
+}
+
+func NewRemoveTransformerPlugin() resmap.TransformerPlugin {
+	return &RemoveTransformerPlugin{}
+}

--- a/pkg/plugins/builtinplugintype_string.go
+++ b/pkg/plugins/builtinplugintype_string.go
@@ -28,11 +28,12 @@ func _() {
 	_ = x[HelmChartInflationGenerator-17]
 	_ = x[ReplacementTransformer-18]
 	_ = x[GitConfigMapGenerator-19]
+	_ = x[RemoveTransformer-20]
 }
 
-const _BuiltinPluginType_name = "UnknownAnnotationsTransformerConfigMapGeneratorIAMPolicyGeneratorHashTransformerImageTagTransformerLabelTransformerNamespaceTransformerPatchJson6902TransformerPatchStrategicMergeTransformerPatchTransformerPrefixSuffixTransformerPrefixTransformerSuffixTransformerReplicaCountTransformerSecretGeneratorValueAddTransformerHelmChartInflationGeneratorReplacementTransformerGitConfigMapGenerator"
+const _BuiltinPluginType_name = "UnknownAnnotationsTransformerConfigMapGeneratorIAMPolicyGeneratorHashTransformerImageTagTransformerLabelTransformerNamespaceTransformerPatchJson6902TransformerPatchStrategicMergeTransformerPatchTransformerPrefixSuffixTransformerPrefixTransformerSuffixTransformerReplicaCountTransformerSecretGeneratorValueAddTransformerHelmChartInflationGeneratorReplacementTransformerGitConfigMapGeneratorRemoveTransformer"
 
-var _BuiltinPluginType_index = [...]uint16{0, 7, 29, 47, 65, 80, 99, 115, 135, 159, 189, 205, 228, 245, 262, 285, 300, 319, 346, 368, 389}
+var _BuiltinPluginType_index = [...]uint16{0, 7, 29, 47, 65, 80, 99, 115, 135, 159, 189, 205, 228, 245, 262, 285, 300, 319, 346, 368, 389, 406}
 
 func (i BuiltinPluginType) String() string {
 	if i < 0 || i >= BuiltinPluginType(len(_BuiltinPluginType_index)-1) {

--- a/pkg/plugins/factories.go
+++ b/pkg/plugins/factories.go
@@ -38,6 +38,7 @@ const (
 	HelmChartInflationGenerator
 	ReplacementTransformer
 	GitConfigMapGenerator
+	RemoveTransformer
 )
 
 var stringToBuiltinPluginTypeMap map[string]BuiltinPluginType
@@ -109,6 +110,7 @@ var TransformerFactories = map[BuiltinPluginType]func() resmap.TransformerPlugin
 	ReplacementTransformer:         extras.NewExtendedReplacementTransformerPlugin,
 	ReplicaCountTransformer:        builtins.NewReplicaCountTransformerPlugin,
 	ValueAddTransformer:            builtins.NewValueAddTransformerPlugin,
+	RemoveTransformer:              extras.NewRemoveTransformerPlugin,
 	// Do not wired SortOrderTransformer as a builtin plugin.
 	// We only want it to be available in the top-level kustomization.
 	// See: https://github.com/kubernetes-sigs/kustomize/issues/3913

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -23,7 +23,7 @@ const (
 	FunctionAnnotationFunction = ConfigurationAnnotationDomain + "/function"
 
 	// true when the resource is part of the local configuration
-	FunctionAnnotationLocalConfig = ConfigurationAnnotationDomain + "/local-config"
+	FunctionAnnotationLocalConfig = LocalConfigurationAnnotationDomain + "/local-config"
 
 	// Setting to true means we want this function configuration to be injected as a
 	// local configuration resource (local-config)

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -31,8 +31,8 @@ const (
 
 	// if set, the transformation will remove all the resources marked as local-config
 	FunctionAnnotationPruneLocal = LocalConfigurationAnnotationDomain + "/prune-local"
-	// if set on a Generated resource, it won't be pruned
-	FunctionAnnotationKeepLocal = LocalConfigurationAnnotationDomain + "/keep-local"
-	FunctionAnnotationPath      = LocalConfigurationAnnotationDomain + "/path"
-	FunctionAnnotationIndex     = LocalConfigurationAnnotationDomain + "/index"
+	// Saving path for injected resource
+	FunctionAnnotationPath = LocalConfigurationAnnotationDomain + "/path"
+	// Saving index for injected resource
+	FunctionAnnotationIndex = LocalConfigurationAnnotationDomain + "/index"
 )

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strconv"
+
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -36,29 +38,50 @@ func RemoveBuildAnnotations(r *resource.Resource) {
 	}
 }
 
-func MakeResourceLocal(r *yaml.RNode) error {
-	annotations := r.GetAnnotations()
+func TransferAnnotations(list []*yaml.RNode, config *yaml.RNode) (err error) {
+	path := ".krmfnbuiltin.yaml"
+	startIndex := 0
 
-	annotations[FunctionAnnotationLocalConfig] = "true"
-	if _, ok := annotations[kioutil.PathAnnotation]; !ok {
-		annotations[kioutil.PathAnnotation] = ".generated.yaml"
-	}
-	if _, ok := annotations[kioutil.LegacyPathAnnotation]; !ok {
-		annotations[kioutil.LegacyPathAnnotation] = ".generated.yaml"
-	}
-	delete(annotations, FunctionAnnotationInjectLocal)
-	delete(annotations, FunctionAnnotationFunction)
+	configAnnotations := config.GetAnnotations()
+	_, local := configAnnotations[FunctionAnnotationLocalConfig]
 
-	return r.SetAnnotations(annotations)
+	if annoPath, ok := configAnnotations[FunctionAnnotationPath]; ok {
+		path = annoPath
+	}
+
+	if annoIndex, ok := configAnnotations[FunctionAnnotationIndex]; ok {
+		startIndex, err = strconv.Atoi(annoIndex)
+		if err != nil {
+			return
+		}
+	}
+
+	for index, r := range list {
+		annotations := r.GetAnnotations()
+		if local {
+			annotations[FunctionAnnotationLocalConfig] = "true"
+		}
+		annotations[kioutil.LegacyPathAnnotation] = path
+		annotations[kioutil.PathAnnotation] = path
+
+		curIndex := strconv.Itoa(startIndex + index)
+		annotations[kioutil.LegacyIndexAnnotation] = curIndex
+		annotations[kioutil.IndexAnnotation] = curIndex
+		delete(annotations, FunctionAnnotationInjectLocal)
+		delete(annotations, FunctionAnnotationFunction)
+		r.SetAnnotations(annotations)
+	}
+	return
 }
 
 func unLocal(list []*yaml.RNode) ([]*yaml.RNode, error) {
 	output := []*yaml.RNode{}
 	for _, r := range list {
 		annotations := r.GetAnnotations()
-		if _, ok := annotations[FunctionAnnotationKeepLocal]; ok {
-			delete(annotations, FunctionAnnotationKeepLocal)
-			delete(annotations, FunctionAnnotationLocalConfig)
+		// We don't append resources with config.kaweezle.com/local-config resources
+		if _, ok := annotations[FunctionAnnotationLocalConfig]; !ok {
+			// For the remaining resources, if a path and/or index was specified
+			// we copy it.
 			if path, ok := annotations[FunctionAnnotationPath]; ok {
 				annotations[kioutil.LegacyPathAnnotation] = path
 				annotations[kioutil.PathAnnotation] = path
@@ -71,10 +94,6 @@ func unLocal(list []*yaml.RNode) ([]*yaml.RNode, error) {
 			}
 			r.SetAnnotations(annotations)
 			output = append(output, r)
-		} else {
-			if _, ok := annotations[FunctionAnnotationLocalConfig]; !ok {
-				output = append(output, r)
-			}
 		}
 	}
 	return output, nil

--- a/tests/multi-replacement/functions/01_multi-transformation.yaml
+++ b/tests/multi-replacement/functions/01_multi-transformation.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configuration-map
   annotations:
     config.kaweezle.com/inject-local: "true"
+    config.kaweezle.com/local-config: "true"
     config.kubernetes.io/function: |
       exec:
         path: ../../krmfnbuiltin

--- a/tests/multi-replacement/functions/01_multi-transformation.yaml
+++ b/tests/multi-replacement/functions/01_multi-transformation.yaml
@@ -1,0 +1,17 @@
+apiVersion: builtin
+kind: LocalConfiguration
+metadata:
+  name: configuration-map
+  annotations:
+    config.kaweezle.com/inject-local: "true"
+    config.kubernetes.io/function: |
+      exec:
+        path: ../../krmfnbuiltin
+data:
+  sish:
+    server: target.link
+    hostname: myhost.target.link
+    host_key: AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAID+4/eqtPTLC18TE8ZP7NeF4ZP68/wnY2d7mhH/KVs79AAAABHNzaDo=
+  traefik:
+    dashboard_enabled: true
+    expose: true

--- a/tests/multi-replacement/functions/02_multi-transformation.yaml
+++ b/tests/multi-replacement/functions/02_multi-transformation.yaml
@@ -3,7 +3,7 @@ kind: ReplacementTransformer
 metadata:
   name: replacement-transformer
   annotations:
-    config.kubernetes.io/prune-local: "true"
+    ## config.kaweezle.com/prune-local: "true"
     config.kubernetes.io/function: |
       exec:
         path: ../../krmfnbuiltin

--- a/tests/multi-replacement/functions/02_multi-transformation.yaml
+++ b/tests/multi-replacement/functions/02_multi-transformation.yaml
@@ -1,22 +1,4 @@
 apiVersion: builtin
-kind: LocalConfiguration
-metadata:
-  name: configuration-map
-  annotations:
-    config.kaweezle.com/inject-local: "true"
-    config.kubernetes.io/function: |
-      exec:
-        path: ../../krmfnbuiltin
-data:
-  sish:
-    server: target.link
-    hostname: myhost.target.link
-    host_key: AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAID+4/eqtPTLC18TE8ZP7NeF4ZP68/wnY2d7mhH/KVs79AAAABHNzaDo=
-  traefik:
-    dashboard_enabled: true
-    expose: true
----
-apiVersion: builtin
 kind: ReplacementTransformer
 metadata:
   name: replacement-transformer

--- a/tests/multi-replacement/functions/03_multi-transformation.yaml
+++ b/tests/multi-replacement/functions/03_multi-transformation.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: RemoveTransformer
+metadata:
+  name: replacement-transformer
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ../../krmfnbuiltin
+targets:
+  - annotationSelector: config.kaweezle.com/local-config

--- a/tests/replacement/functions/01_configmap-generator.yaml
+++ b/tests/replacement/functions/01_configmap-generator.yaml
@@ -6,6 +6,7 @@ metadata:
   name: configuration-map
   namespace: argocd
   annotations:
+    config.kaweezle.com/local-config: "true"
     config.kubernetes.io/function: |
       exec:
         path: ../../krmfnbuiltin

--- a/tests/test_krmfnbuiltin.sh
+++ b/tests/test_krmfnbuiltin.sh
@@ -9,7 +9,6 @@ set -e pipefail
 
 trap "find . -type d -name 'applications' -exec rm -rf {} +" EXIT
 
-
 for d in $(ls -d */); do
     echo "Running Test in $d..."
     cd $d
@@ -17,7 +16,7 @@ for d in $(ls -d */); do
     cp -r original applications
     echo "  > Performing kustomizations..."
     kustomize fn run --enable-exec --fn-path functions applications
-    for f in $(ls -1 expected); do
+    for f in $(ls -1 applications); do
         echo "  > Checking $f..."
         diff <(yq eval -P expected/$f) <(yq eval -P applications/$f)
     done

--- a/tests/test_krmfnbuiltin_kpt.sh
+++ b/tests/test_krmfnbuiltin_kpt.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# DEPENDENCEIS
+# kustomize
+# yq
+
+#set -uexo pipefail
+set -e pipefail
+
+temp_file=$(mktemp)
+temp_file_2=$(mktemp)
+
+trap "find . -type d -name 'applications' -exec rm -rf {} +; rm -f $temp_file $temp_file_2" EXIT
+
+for d in $(ls -d */); do
+    echo "Running Test in $d..."
+    cd $d
+    rm -rf applications
+    echo "  > Performing kustomizations..."
+    kpt fn source original >$temp_file
+    for f in functions/*; do
+        cat $temp_file | kpt fn eval - --exec ../../krmfnbuiltin --fn-config $f >$temp_file_2
+        mv $temp_file_2 $temp_file
+    done
+    cat $temp_file | kpt fn sink applications
+    for f in $(ls -1 expected); do
+        echo "  > Checking $f..."
+        diff <(yq eval -P expected/$f) <(yq eval -P applications/$f)
+    done
+    cd ..
+done
+echo "Done ok 🎉"


### PR DESCRIPTION
kpt only does a function at once, and honors the removal
of the `config.kuberntes.io/local-config` marked resources.

In consequence, we cannot use `config.kuberntes.io/local-config`
anymore to inject resources. We replace it with
 `config.kaweezle.com/local-config`.

`prune-local` is not a workaround anymore  but becomes
a feature. The README needs to be adapted in consequence.