### PR TITLE
🐛 ✨ Introduce new annotation to cleanup annotations

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,15 +62,19 @@ func main() {
 				return errors.WrapPrefixf(err, "Transforming resources")
 			}
 
-			for _, r := range rm.Resources() {
-				utils.RemoveBuildAnnotations(r)
+			configAnnotations := config.GetAnnotations()
+
+			if _, ok := configAnnotations[utils.FunctionAnnotationCleanup]; ok {
+				for _, r := range rm.Resources() {
+					utils.RemoveBuildAnnotations(r)
+				}
 			}
 
 			rl.Items = rm.ToRNodeSlice()
 
 			// If the annotation `config.kaweezle.com/prune-local` is present in a
 			// transformer makes all the local resources disappear.
-			if _, ok := config.GetAnnotations()[utils.FunctionAnnotationPruneLocal]; ok {
+			if _, ok := configAnnotations[utils.FunctionAnnotationPruneLocal]; ok {
 				err = rl.Filter(utils.UnLocal)
 				if err != nil {
 					return errors.WrapPrefixf(err, "while pruning `config.kaweezle.com/local-config` resources")
@@ -110,7 +114,7 @@ func main() {
 
 	cmd := command.Build(processor, command.StandaloneDisabled, false)
 	command.AddGenerateDockerfile(cmd)
-	cmd.Version = "v0.4.0" // <---VERSION--->
+	cmd.Version = "v0.4.1" // <---VERSION--->
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -29,6 +29,9 @@ const (
 	// local configuration resource (local-config)
 	FunctionAnnotationInjectLocal = LocalConfigurationAnnotationDomain + "/inject-local"
 
+	// if set, Remove any transformation leftover annotations
+	FunctionAnnotationCleanup = LocalConfigurationAnnotationDomain + "/cleanup"
+
 	// if set, the transformation will remove all the resources marked as local-config
 	FunctionAnnotationPruneLocal = LocalConfigurationAnnotationDomain + "/prune-local"
 	// Saving path for injected resource

--- a/tests/patch/functions/patch-transformer.yaml
+++ b/tests/patch/functions/patch-transformer.yaml
@@ -3,6 +3,7 @@ kind: PatchTransformer
 metadata:
   name: not-important-to-example
   annotations:
+    config.kaweezle.com/cleanup: "true"
     config.kubernetes.io/function: |
       exec:
         path: ../../krmfnbuiltin


### PR DESCRIPTION
After transformation, we were deleting all internal annotations.
When using krmfnbuiltin in the context of a kustomize build, we
don't want those annotation to disappear. For instance, this would
prevent hash generation for secrets and configmaps.

But in the context of a single function execution, we want to keep
it. This is the reason we have added a specific annotation for that.