### PR TITLE
✅ Add a test for domain replacement

### DIFF
--- a/tests/sourced-replacement/expected/argocd-ingress.yaml
+++ b/tests/sourced-replacement/expected/argocd-ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-issuer
+    external-dns.alpha.kubernetes.io/ttl: "60"
+    # This is needed to avoid creating a DNS entry with local IP address
+    external-dns.alpha.kubernetes.io/target: develop.cx
+    ingress.kubernetes.io/auth-secret: argo-sso
+  labels:
+    app.kubernetes.io/name: argocd-sish
+    app.kubernetes.io/component: edge
+    app.kubernetes.io/part-of: autocloud
+  name: argocd-sish
+  namespace: argocd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: argocd-devenv.develop.cx
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - argocd-devenv.develop.cx
+      secretName: argocd-devenv.develop.cx-tls

--- a/tests/sourced-replacement/functions/argocd-values-replacements.yaml
+++ b/tests/sourced-replacement/functions/argocd-values-replacements.yaml
@@ -37,3 +37,28 @@ replacements:
           name: argocd-cm
         fieldPaths:
           - data.b64encoded
+  - source:
+      name: autocloud-values
+      fieldPath: data.cluster.argocd.domainPrefix
+    targets:
+      - select:
+          kind: Ingress
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+          - spec.tls.0.secretName
+        options:
+          delimiter: "."
+          index: 0
+  - source:
+      name: autocloud-values
+      fieldPath: data.ovh.dnsZone
+    targets:
+      - select:
+          kind: Ingress
+          name: argocd-sish
+        fieldPaths:
+          - spec.rules.0.host.!!regex.^[\w-]+\\.(\.*)$.1
+          - spec.tls.0.hosts.0.!!regex.^[\w-]+\\.(\.*)$.1
+          - spec.tls.0.secretName.!!regex.^[\w-]+\\.(\.*)-tls$.1
+          - metadata.annotations.external-dns\.alpha\.kubernetes\.io/target

--- a/tests/sourced-replacement/original/argocd-ingress.yaml
+++ b/tests/sourced-replacement/original/argocd-ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-issuer
+    external-dns.alpha.kubernetes.io/ttl: "60"
+    # This is needed to avoid creating a DNS entry with local IP address
+    external-dns.alpha.kubernetes.io/target: holepunch.in
+    ingress.kubernetes.io/auth-secret: argo-sso
+  labels:
+    app.kubernetes.io/name: argocd-sish
+    app.kubernetes.io/component: edge
+    app.kubernetes.io/part-of: autocloud
+  name: argocd-sish
+  namespace: argocd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: citest.holepunch.in
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - citest.holepunch.in
+      secretName: citest.holepunch.in-tls

--- a/tests/sourced-replacement/values/properties.yaml
+++ b/tests/sourced-replacement/values/properties.yaml
@@ -10,3 +10,8 @@ data:
     email: john@doe.me
     clientID: thisisfakeclientid
   to_encode: This is the value to encode in base64
+  ovh:
+    dnsZone: develop.cx
+  cluster:
+    argocd:
+      domainPrefix: argocd-devenv


### PR DESCRIPTION
There was an error in the regex we used for subdomain replacement
when the name had a `-` character.